### PR TITLE
Fix myEvent memory into storage

### DIFF
--- a/contracts/Web3RSVP.sol
+++ b/contracts/Web3RSVP.sol
@@ -161,7 +161,7 @@ contract Web3RSVP {
 
     function withdrawUnclaimedDeposits(bytes32 eventId) external {
         // look up event
-        CreateEvent memory myEvent = idToEvent[eventId];
+        CreateEvent storage myEvent = idToEvent[eventId];
 
         // check if already paid
         require(!myEvent.paidOut, "ALREADY PAID");


### PR DESCRIPTION
In the withdrawUnclaimedDeposits funtion we set myEvent.paidOut equal to true but if myEvent is memory it never actually update the contract